### PR TITLE
Update Firebase App Distribution workflow to use correct service account

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -51,7 +51,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Create Google Play Service Account JSON file
-        run: echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' | base64 -d > app/google-services.json
+        run: echo '${{ secrets.FIREBASE_GOOGLE_SERVICE_JSON }}' | base64 -d > app/google-services.json
 
       - name: Create release directory
         run: mkdir -p app/release


### PR DESCRIPTION
This pull request updates the Firebase App Distribution workflow to use a different secret for creating the Google Play Service Account JSON file.

Key change:

* [`.github/workflows/firebase-app-distribution.yml`](diffhunk://#diff-be98763200e8fd0b98619af4e768fec974ed7cf5e38a338216a173a087734f7fL54-R54): Updated the workflow to use `secrets.FIREBASE_GOOGLE_SERVICE_JSON` instead of `secrets.FIREBASE_SERVICE_ACCOUNT` when creating the `google-services.json` file.…unt secret